### PR TITLE
(#8): Remove "is request already in progress" checks

### DIFF
--- a/src/main/java/cache/Cache.kt
+++ b/src/main/java/cache/Cache.kt
@@ -2,6 +2,7 @@ package cache
 
 interface Cache<K, V> {
   suspend fun store(key: K, value: V)
+  suspend fun contains(key: K): Boolean
   suspend fun get(key: K): V?
   suspend fun remove(key: K)
   suspend fun size(): Int


### PR DESCRIPTION
This is bad when there are multiple imageviews with an the same image.
Closes #8 